### PR TITLE
Reduce replication commands send to server by using client side cache

### DIFF
--- a/pkg/failover-client/client.go
+++ b/pkg/failover-client/client.go
@@ -40,9 +40,10 @@ func NewFailoverClient(cfg ValkeyConfig) *FailoverClient {
 
 	for i, addr := range cfg.Nodes {
 		nodes[i] = &node{
-			address: addr,
-			port:    cfg.Port,
-			up:      true,
+			address:   addr,
+			port:      cfg.Port,
+			up:        true,
+			roleCache: &roleCache{},
 		}
 	}
 
@@ -128,7 +129,7 @@ func (c *FailoverClient) Run() {
 			slog.Error("Failed to retrieve info from virtual address", slog.String("addr", c.virtualAddress), "err", err)
 			continue
 		}
-		currentMaster := parseRunIDFromInfo(res)
+		currentMaster := ParseValueFromInfo(res, runID)
 		if currentMaster != c.currentMaster {
 			found := false
 			for _, n := range c.nodes {
@@ -139,10 +140,10 @@ func (c *FailoverClient) Run() {
 				}
 			}
 			if found {
-				slog.Error("Could not find the current masters addr", slog.String("run_id", currentMaster))
+				slog.Error("Could not find the current masters addr", slog.String(runID, currentMaster))
 				continue
 			} else {
-				slog.Info("Failing over to new master", slog.String("addr", c.masterAddr), slog.String("run_id", c.currentMaster))
+				slog.Info("Failing over to new master", slog.String("addr", c.masterAddr), slog.String(runID, c.currentMaster))
 			}
 		}
 

--- a/pkg/failover-client/node_test.go
+++ b/pkg/failover-client/node_test.go
@@ -2,6 +2,7 @@ package failoverclient
 
 import (
 	"testing"
+	"time"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/stretchr/testify/assert"
@@ -16,9 +17,12 @@ func TestNodeConnect(t *testing.T) {
 		address: mr.Host(),
 		port:    int64(mr.Server().Addr().Port),
 	}
-	err := n.connect(t.Context(), valkey.ClientOption{})
+	err := n.connect(t.Context(), valkey.ClientOption{
+		DisableCache: true,
+		DisableRetry: true,
+	})
 
-	assert.Error(err, "Should fail to retrieve information")
+	assert.Equal("section (server) is not supported", err.Error(), "Should return miniredis error")
 	assert.Nil(n.client, "Should not set client")
 	assert.False(n.up, "Should not mark node as up")
 	assert.Empty(n.runID, "Should have no run_id")
@@ -26,23 +30,11 @@ func TestNodeConnect(t *testing.T) {
 
 func TestNodePing(t *testing.T) {
 	assert := assert.New(t)
-	mr := miniredis.RunT(t)
 	ctx := t.Context()
 
-	opt := valkey.ClientOption{
-		InitAddress:  []string{mr.Addr()},
-		DisableCache: true,
-		DisableRetry: true,
-	}
-	client, err := valkey.NewClient(opt)
-	if !assert.NoError(err, "Should create valkey client") {
+	mr, n, err := newNodeWithMiniredis(t)
+	if !assert.NoError(err, "Should create node with client") {
 		t.FailNow()
-	}
-
-	n := &node{
-		address: mr.Host(),
-		port:    int64(mr.Server().Addr().Port),
-		client:  client,
 	}
 
 	n.ping(ctx)
@@ -54,4 +46,154 @@ func TestNodePing(t *testing.T) {
 	n.ping(ctx)
 	assert.Nil(n.client, "Node should close client")
 	assert.False(n.up, "Node should be down")
+}
+
+func TestNodeMaster(t *testing.T) {
+	t.Run("NoClient", func(t *testing.T) {
+		assert.Error(t, (&node{}).master(t.Context()), "Should not panic when client is nil")
+	})
+	t.Run("CacheHit", func(t *testing.T) {
+		assert := assert.New(t)
+
+		mr, n, err := newNodeWithMiniredis(t)
+		if !assert.NoError(err, "Should create node with client") {
+			t.FailNow()
+		}
+
+		mr.Close()
+		n.roleCache.Save(master, "")
+
+		assert.Nil(n.master(t.Context()), "Should hit cache and not attempt to connect to server")
+	})
+	t.Run("CacheExpired", func(t *testing.T) {
+		assert := assert.New(t)
+
+		mr, n, err := newNodeWithMiniredis(t)
+		if !assert.NoError(err, "Should create node with client") {
+			t.FailNow()
+		}
+
+		mr.Close()
+		n.roleCache.Save(master, "")
+		n.roleCache.expire = time.Now().Add(-time.Minute)
+
+		assert.Error(n.master(t.Context()), "Should not hit the cache and error out instead")
+	})
+	t.Run("CacheEmpty", func(t *testing.T) {
+		assert := assert.New(t)
+
+		mr, n, err := newNodeWithMiniredis(t)
+		if !assert.NoError(err, "Should create node with client") {
+			t.FailNow()
+		}
+
+		mr.Close()
+
+		assert.Error(n.master(t.Context()), "Should not hit the cache and error out instead")
+		assert.Empty(n.roleCache, "Should not save to cache on error")
+	})
+}
+
+func TestNodeSlave(t *testing.T) {
+	t.Run("NoClient", func(t *testing.T) {
+		assert.NoError(t, (&node{}).slave(t.Context(), "testmaster"), "Should not panic when client is nil")
+	})
+	t.Run("CacheHit", func(t *testing.T) {
+		assert := assert.New(t)
+
+		mr, n, err := newNodeWithMiniredis(t)
+		if !assert.NoError(err, "Should create node with client") {
+			t.FailNow()
+		}
+
+		mr.Close()
+		n.roleCache.Save(slave, "testmaster")
+
+		assert.Nil(n.slave(t.Context(), "testmaster"), "Should hit cache and not attempt to connect to server")
+	})
+	t.Run("CacheExpired", func(t *testing.T) {
+		assert := assert.New(t)
+
+		mr, n, err := newNodeWithMiniredis(t)
+		if !assert.NoError(err, "Should create node with client") {
+			t.FailNow()
+		}
+
+		mr.Close()
+		n.roleCache.Save(slave, "testmaster")
+		n.roleCache.expire = time.Now().Add(-time.Minute)
+
+		assert.Error(n.slave(t.Context(), "testmaster"), "Should not hit the cache and error out instead")
+	})
+	t.Run("CacheEmpty", func(t *testing.T) {
+		assert := assert.New(t)
+
+		mr, n, err := newNodeWithMiniredis(t)
+		if !assert.NoError(err, "Should create node with client") {
+			t.FailNow()
+		}
+
+		mr.Close()
+
+		assert.Error(n.slave(t.Context(), "testmaster"), "Should not hit the cache and error out instead")
+		assert.Empty(n.roleCache, "Should not save to cache on error")
+	})
+}
+
+func TestNodeCacheSave(t *testing.T) {
+	_, c := newSetupAndClient(t, "node-cache-save", 2)
+
+	for i, n := range c.nodes {
+		err := n.connect(t.Context(), valkey.ClientOption{})
+		if !assert.NoErrorf(t, err, "Should connect to node %d", i) {
+			t.FailNow()
+		}
+	}
+
+	t.Run("Master", func(t *testing.T) {
+		assert := assert.New(t)
+		n := c.nodes[0]
+
+		err := n.master(t.Context())
+
+		assert.NoError(err, "Should set node to master")
+		assert.Equal(master, n.roleCache.role, "Should save role in cache")
+		assert.NotEmpty(n.roleCache.expire, "Should set expire time")
+		assert.False(n.roleCache.isExpired(), "Cache should not be expired")
+	})
+	t.Run("Slave", func(t *testing.T) {
+		assert := assert.New(t)
+		n := c.nodes[1]
+
+		err := n.slave(t.Context(), c.virtualAddress)
+
+		assert.NoError(err, "Should set node to slave")
+		assert.Equal(slave, n.roleCache.role, "Should save role in cache")
+		assert.Equal(c.virtualAddress, n.roleCache.masterHost, "Should save master_host in cache")
+		assert.NotEmpty(n.roleCache.expire, "Should set expire time")
+		assert.False(n.roleCache.isExpired(), "Cache should not be expired")
+	})
+}
+
+func newNodeWithMiniredis(t *testing.T) (*miniredis.Miniredis, *node, error) {
+	mr := miniredis.RunT(t)
+
+	opt := valkey.ClientOption{
+		InitAddress:  []string{mr.Addr()},
+		DisableCache: true,
+		DisableRetry: true,
+	}
+	client, err := valkey.NewClient(opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	n := &node{
+		address:   mr.Host(),
+		port:      int64(mr.Server().Addr().Port),
+		client:    client,
+		roleCache: &roleCache{},
+	}
+
+	return mr, n, nil
 }

--- a/pkg/failover-client/utils.go
+++ b/pkg/failover-client/utils.go
@@ -30,7 +30,3 @@ func ParseValueFromInfo(info string, key string) string {
 	slog.Error("Could not find the requested key in info", "info", info, "key", key)
 	return ""
 }
-
-func parseRunIDFromInfo(info string) string {
-	return ParseValueFromInfo(info, "run_id")
-}

--- a/pkg/failover-client/utils_test.go
+++ b/pkg/failover-client/utils_test.go
@@ -10,9 +10,9 @@ func TestParseValueFromInfo(t *testing.T) {
 	info := "txt:# Replication\r\nrole:master\r\nconnected_slaves:2\r\nslave0:ip=10.88.0.170,port=6379,state=wait_bgsave,offset=0,lag=0,type=replica\r\nslave1:ip=10.88.0.171,port=6379,state=wait_bgsave,offset=0,lag=0,type=replica\r\nreplicas_waiting_psync:0\r\nmaster_failover_state:no-failover\r\nmaster_replid:240bcba5fe13f68d5fa1d9ab84e3e3878b68552a\r\nmaster_replid2:0000000000000000000000000000000000000000\r\nmaster_repl_offset:0\r\nsecond_repl_offset:-1\r\nrepl_backlog_active:1\r\nrepl_backlog_size:10485760\r\nrepl_backlog_first_byte_offset:1\r\nrepl_backlog_histlen:0\r\n"
 	assert := assert.New(t)
 
-	assert.Equal(master, ParseValueFromInfo(info, "role"))
+	assert.Equal(master, ParseValueFromInfo(info, role))
 
-	assert.Equal(master, ParseValueFromInfo("\r\ntest\r\nrole:master\r\nconnected_slaves:2", "role"), "Should not panic when split does not work correctly")
+	assert.Equal(master, ParseValueFromInfo("\r\ntest\r\nrole:master\r\nconnected_slaves:2", role), "Should not panic when split does not work correctly")
 
 	assert.Equal("", ParseValueFromInfo("", "not-a-key"), "Should return an empty string if no value is found")
 }


### PR DESCRIPTION
Implement client side role cache.
Reduce calls to server by caching last role for 1m. Avoid calling replicaof when nothin changed by querying for info first.