### PR TITLE
Fix wrong log message displayed on startup

### DIFF
--- a/pkg/failover-client/client.go
+++ b/pkg/failover-client/client.go
@@ -82,14 +82,14 @@ func (c *FailoverClient) updateNodes() {
 		if n.client == nil {
 			err := n.connect(ctx, c.clientOption)
 			if err != nil {
+				logLevel := slog.LevelDebug
 				if n.up {
-					slog.Warn(failedToConnectToNodeMsg, slog.String("node", n.address), "err", err)
+					logLevel = slog.LevelWarn
 					n.up = false
-				} else {
-					slog.Debug(failedToConnectToNodeMsg, slog.String("node", n.address), "err", err)
 				}
-				return
+				slog.Log(ctx, logLevel, nodeDownMsg, slog.String("node", n.address), "err", err)
 			}
+			return
 		}
 
 		n.ping(ctx)
@@ -139,11 +139,11 @@ func (c *FailoverClient) Run() {
 					found = true
 				}
 			}
-			if found {
+			if !found {
 				slog.Error("Could not find the current masters addr", slog.String(runID, currentMaster))
 				continue
 			} else {
-				slog.Info("Failing over to new master", slog.String("addr", c.masterAddr), slog.String(runID, c.currentMaster))
+				slog.Info("Switching over to new master", slog.String("addr", c.masterAddr), slog.String(runID, c.currentMaster))
 			}
 		}
 

--- a/pkg/failover-client/node.go
+++ b/pkg/failover-client/node.go
@@ -29,7 +29,10 @@ type node struct {
 	roleCache *roleCache
 }
 
-const failedToConnectToNodeMsg = "Failed to connect to node"
+const (
+	nodeDownMsg = "Node is DOWN"
+	nodeUpMsg   = "Node is UP"
+)
 
 // Connect to valkey and retrieve the run_id
 func (n *node) connect(ctx context.Context, option valkey.ClientOption) error {
@@ -57,14 +60,14 @@ func (n *node) ping(ctx context.Context) {
 	res, err := n.client.Do(ctx, n.client.B().Ping().Build()).ToString()
 	if err != nil || res != "PONG" {
 		if n.up {
-			slog.Info("Node is DOWN", slog.String("node", n.address), "err", err, slog.String("res", res))
+			slog.Info(nodeDownMsg, slog.String("node", n.address), "err", err, slog.String("res", res))
 			n.up = false
 		}
 		n.client.Close()
 		n.client = nil
 	} else if !n.up {
 		n.up = true
-		slog.Info("Node is UP", slog.String("node", n.address))
+		slog.Info(nodeUpMsg, slog.String("node", n.address))
 	}
 }
 


### PR DESCRIPTION
Fix wrongly displayed log message of master not found on startup. Improve log message handling when (re)connecting to nodes.