### PR TITLE
Fix code alerts found by gosec

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,6 +56,7 @@ func LoadConfig(path string, env bool) (Config, error) {
 		path = DEFAULT_CONFIG_PATH
 	}
 
+	// #nosec G304: Local users can decide on the config file path freely.
 	f, err := os.ReadFile(path)
 	if err != nil {
 		return Config{}, err

--- a/pkg/failover-client/client.go
+++ b/pkg/failover-client/client.go
@@ -33,7 +33,9 @@ func NewFailoverClient(cfg ValkeyConfig) *FailoverClient {
 		DisableRetry: true,
 	}
 	if cfg.TLS {
-		option.TLSConfig = &tls.Config{}
+		option.TLSConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
 	}
 
 	nodes := make([]*node, len(cfg.Nodes))

--- a/tests/utils/container.go
+++ b/tests/utils/container.go
@@ -17,6 +17,7 @@ func findContainerRuntime() string {
 		if err != nil {
 			continue
 		}
+		// #nosec G204: Path of container runtime is determined dynamically and based of PATH.
 		err = exec.Command(path, "ps").Run()
 		if err == nil {
 			fmt.Printf("Found container runtime %s, path=%s\n", cmd, path)
@@ -49,6 +50,7 @@ func GetCommand(args ...string) *exec.Cmd {
 		args = append([]string{containerRuntime}, args...)
 		return exec.Command("sudo", args...)
 	}
+	// #nosec G204: Path of container runtime is determined dynamically and based of PATH.
 	return exec.Command(containerRuntime, args...)
 }
 


### PR DESCRIPTION
Ensure valkey tls configuration uses sensible minimum TLS version.
Add #nosec comments with justification where appropiate.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>