### PR TITLE
tests/utils: Fix haproxy config

### DIFF
--- a/tests/utils/failover.go
+++ b/tests/utils/failover.go
@@ -13,7 +13,7 @@ const haproxyConfigTemplate = `global
 		timeout connect 1s
 		timeout server 1s
 
-	frontend valkey
+	frontend valkey-failover
 		mode tcp
 		bind :6379
 		default_backend valkey


### PR DESCRIPTION
Latest haproxy version does not allow same names for frontend/backend.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>